### PR TITLE
Small correction minum_range to minimum_range in Zigbee2MQTTHelper

### DIFF
--- a/libs/Zigbee2MQTTHelper.php
+++ b/libs/Zigbee2MQTTHelper.php
@@ -913,7 +913,7 @@ trait Zigbee2MQTTHelper
                     $this->SetValue('Z2M_TargetDistance', $Payload['target_distance']);
                 }
                 if (array_key_exists('minimum_range', $Payload)) {
-                    $this->SetValue('Z2M_MinimumRange', $Payload['minum_range']);
+                    $this->SetValue('Z2M_MinimumRange', $Payload['minimum_range']);
                 }
                 if (array_key_exists('maximum_range', $Payload)) {
                     $this->SetValue('Z2M_MaximumRange', $Payload['maximum_range']);


### PR DESCRIPTION
Moin,

da ist ein kleiner Schreibfehler, der mein System mit Fehlern zuschmeißt und es so zum erliegen bringt. 